### PR TITLE
Simplify shared CI workflow inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,6 @@ jobs:
       id-token: write   # This is required for requesting the JWT
       contents: read    # This is required for actions/checkout
     uses: bioio-devs/bioio-base/.github/workflows/shared_test.yml@main
-    with:
-      test_checkout_lfs: true
 
   # Check package performance
   benchmark:


### PR DESCRIPTION
Make use of shared_ci with reduced args.

This pull request resolves # https://github.com/bioio-devs/bioio-base/issues/55

### Description of Changes

Remove unneeded parameters
